### PR TITLE
302 auto outliers

### DIFF
--- a/config/subresponder_schema.toml
+++ b/config/subresponder_schema.toml
@@ -107,13 +107,3 @@ Length = "nan"
 Min_values = "nan"
 Max_values = "nan"
 Possible_categorical_Values = ["nan"]
-
-[instance]
-Description = "nan"
-Deduced_Data_Type = "Int64"
-Nullable = false
-Current_Data_Type = "str"
-Length = "nan"
-Min_values = "nan"
-Max_values = "nan"
-Possible_Categorical_Values = ["nan"]

--- a/src/developer_config.yaml
+++ b/src/developer_config.yaml
@@ -25,11 +25,12 @@ network_paths:
   logs_foldername: "logs/run_logs"
   snapshot_path: "R:/BERD Results System Development 2023/DAP_emulation/survey_return_data/snapshot-202212-002-83b5bacd-7c99-45cf-b989-d43d762dd054.json"
   postcode_masterlist: "R:/BERD Results System Development 2023/DAP_emulation/ONS_Postcode_Reference/ONSPD_NOV_2022_UK.csv"
-  history_path: 'R:/BERD Results System Development 2023/DAP_emulation/BERD_V7_Anonymised' #'R:\BERD Results System Development 2023\DAP_emulation\backseries\v1'
+  history_path: "R:/BERD Results System Development 2023/DAP_emulation/BERD_V7_Anonymised" #"R:\BERD Results System Development 2023\DAP_emulation\backseries\v1"
   staging_test_foldername: "R:/BERD Results System Development 2023/Staged_Test_Output"
 outliers:
-    upper_clip: 0.05  # enter percentage as a decimal (float)
-    lower_clip: 0.0  # enter percentage as a decimal (float)
+    upper_clip: 0.05  # enter percentage as a decimal (float) - default is 0.05
+    lower_clip: 0.0  # enter percentage as a decimal (float) - default is 0.0
+    flag_cols: ["701", "702", "703", "704", "705", "706", "707"] # NOT for user config. Columns to flag for outliers. 
 csv_filenames:
     main: "main_runlog.csv"
     configs: "configs_runlog.csv"

--- a/src/developer_config.yaml
+++ b/src/developer_config.yaml
@@ -3,10 +3,10 @@ global:
   logging_level: "DEBUG"
   table_config: "SingleLine"
   postcode_csv_check: False
-  network_or_hdfs: hdfs #whether to load from hdfs or network (local Python)
+  network_or_hdfs: network #whether to load from hdfs or network (local Python)
 years:
   current_year: 2022 # TODO: put this in the userconfig
-  previous_years_to_load: 2 # TODO: put this in the userconfig
+  previous_years_to_load: 1 # TODO: put this in the userconfig
 runlog_writer:
     write_csv: True # Write the runlog to a CSV file
     write_hdf5: False # Write the runlog to an HDF5 file
@@ -25,10 +25,10 @@ network_paths:
   logs_foldername: "logs/run_logs"
   snapshot_path: "R:/BERD Results System Development 2023/DAP_emulation/survey_return_data/snapshot-202212-002-83b5bacd-7c99-45cf-b989-d43d762dd054.json"
   postcode_masterlist: "R:/BERD Results System Development 2023/DAP_emulation/ONS_Postcode_Reference/ONSPD_NOV_2022_UK.csv"
-  history_path: 'R:\BERD Results System Development 2023\DAP_emulation\BERD_V7_Anonymised' #'R:\BERD Results System Development 2023\DAP_emulation\backseries\v1'
+  history_path: 'R:/BERD Results System Development 2023/DAP_emulation/BERD_V7_Anonymised' #'R:\BERD Results System Development 2023\DAP_emulation\backseries\v1'
   staging_test_foldername: "R:/BERD Results System Development 2023/Staged_Test_Output"
 outliers:
-    upper_clip: 0.1  # enter percentage as a decimal (float)
+    upper_clip: 0.05  # enter percentage as a decimal (float)
     lower_clip: 0.0  # enter percentage as a decimal (float)
 csv_filenames:
     main: "main_runlog.csv"

--- a/src/developer_config.yaml
+++ b/src/developer_config.yaml
@@ -27,6 +27,7 @@ network_paths:
   postcode_masterlist: "R:/BERD Results System Development 2023/DAP_emulation/ONS_Postcode_Reference/ONSPD_NOV_2022_UK.csv"
   history_path: "R:/BERD Results System Development 2023/DAP_emulation/BERD_V7_Anonymised" #"R:\BERD Results System Development 2023\DAP_emulation\backseries\v1"
   staging_test_foldername: "R:/BERD Results System Development 2023/Staged_Test_Output"
+  outliers_path: "R:/BERD Results System Development 2023/DAP_emulation/outliers"
 outliers:
     upper_clip: 0.05  # enter percentage as a decimal (float) - default is 0.05
     lower_clip: 0.0  # enter percentage as a decimal (float) - default is 0.0

--- a/src/developer_config.yaml
+++ b/src/developer_config.yaml
@@ -27,7 +27,9 @@ network_paths:
   postcode_masterlist: "R:/BERD Results System Development 2023/DAP_emulation/ONS_Postcode_Reference/ONSPD_NOV_2022_UK.csv"
   history_path: 'R:\BERD Results System Development 2023\DAP_emulation\BERD_V7_Anonymised' #'R:\BERD Results System Development 2023\DAP_emulation\backseries\v1'
   staging_test_foldername: "R:/BERD Results System Development 2023/Staged_Test_Output"
-
+outliers:
+    upper_clip: 0.1  # enter percentage as a decimal (float)
+    lower_clip: 0.0  # enter percentage as a decimal (float)
 csv_filenames:
     main: "main_runlog.csv"
     configs: "configs_runlog.csv"

--- a/src/outlier_detection/auto_outliers.py
+++ b/src/outlier_detection/auto_outliers.py
@@ -1,9 +1,13 @@
 """Apply outlier detection to the dataset."""
 import logging
 import pandas as pd
-from typing import Tuple, List
+from typing import List
 
 OutlierMainLogger = logging.getLogger(__name__)
+
+# Set defaults
+LOWER_BAND_DEFAULT = 0
+UPPER_BAND_DEFAULT = 1
 
 
 def validate_config(upper_clip: float, lower_clip: float, flag_value_cols: List[str]):
@@ -33,16 +37,15 @@ def validate_config(upper_clip: float, lower_clip: float, flag_value_cols: List[
         raise ImportError
 
     if not isinstance(flag_value_cols, list):
-        
-        OutlierMainLogger.error("In config, flag_value_cols must be specified as a list.")
-        raise ImportError     
+
+        OutlierMainLogger.error(
+            "In config, flag_value_cols must be specified as a list."
+        )
+        raise ImportError
 
 
 def flag_outliers(
-    df: pd.DataFrame,
-    upper_clip: float,
-    lower_clip: float,
-    value_col: str
+    df: pd.DataFrame, upper_clip: float, lower_clip: float, value_col: str
 ) -> pd.DataFrame:
     """Create Boolean column to flag outliers in a given column.
 
@@ -52,19 +55,21 @@ def flag_outliers(
         lower_clip (float): The percentage for lower clipping as float
         value_col (str): The name of the column outliers are calculated for
     Returns:
-        pd.DataFrame: The same dataframe with a new boolean column indicating 
+        pd.DataFrame: The same dataframe with a new boolean column indicating
                         whether the column 'value_col' is an outlier.
     """
-    lower_band = 0 + lower_clip
-    upper_band = 1 - upper_clip
+    lower_band = LOWER_BAND_DEFAULT + lower_clip
+    upper_band = UPPER_BAND_DEFAULT - upper_clip
 
     # Note: selectiontype=='P' doesn't exist in anonymised data!
-    filter_cond = (df[value_col] > 0) & (df.selectiontype=='P')
+    filter_cond = (df[value_col] > 0) & (df.selectiontype == "P")
     filtered_df = df[filter_cond]
     if filtered_df.empty:
-        OutlierMainLogger.error("This data does not contain value 'P' in "
+        OutlierMainLogger.error(
+            "This data does not contain value 'P' in "
             "column 'selectiontype'. \n Note that outliering cannot be "
-            "performed on the current anonomysed spp snapshot data.")
+            "performed on the current anonomysed spp snapshot data."
+        )
         raise ValueError
 
     groupby_cols = ["period", "cellnumber"]
@@ -89,8 +94,9 @@ def flag_outliers(
         groupby_cols + ["lower_band"]
     ]
 
-    df = (df.merge(quantiles_up, on=groupby_cols, how='left')
-            .merge(quantiles_low, on=groupby_cols, how='left'))
+    df = df.merge(quantiles_up, on=groupby_cols, how="left").merge(
+        quantiles_low, on=groupby_cols, how="left"
+    )
 
     outlier_cond = (df[value_col] > df.upper_band) | (df[value_col] < df.lower_band)
 
@@ -107,7 +113,7 @@ def decide_outliers(df: pd.DataFrame, flag_value_cols: List[str]) -> pd.DataFram
     outlier, then the whole reference (ie, row) will be treated as an
     outlier with a flag of 'True' in the auto_outlier column.
 
-    Args: 
+    Args:
         df (pd.DataFrame): The main dataset where outliers are to be calculated
         flag_value_cols: (List[str]): The names of the columns to flag for outliers
 
@@ -122,7 +128,7 @@ def decide_outliers(df: pd.DataFrame, flag_value_cols: List[str]) -> pd.DataFram
 
 def log_outlier_info(df: pd.DataFrame, value_col: str):
     """Log the number of outliers flagged.
-    
+
     Also calculate the total number of non-zero entries in the specified
     value_col column being flagged.
 
@@ -131,32 +137,33 @@ def log_outlier_info(df: pd.DataFrame, value_col: str):
         value_col (str): The name of the col outliers are calculated for
     """
     flag_col = f"{value_col}_outlier_flag"
-    num_flagged = df[df[flag_col]==True][flag_col].count()
+    num_flagged = df[df[flag_col]][flag_col].count()
 
-    tot_nonzero = df[df[value_col]>0][value_col].count()
+    tot_nonzero = df[df[value_col] > 0][value_col].count()
 
-    msg = (f"{num_flagged} outliers were detected out of a total of "
-           f"{tot_nonzero} non-zero entries in column {value_col}")
+    msg = (
+        f"{num_flagged} outliers were detected out of a total of "
+        f"{tot_nonzero} non-zero entries in column {value_col}"
+    )
     OutlierMainLogger.info(msg)
 
 
-def run_auto_flagging(df: pd.DataFrame, 
-                      upper_clip: float, 
-                      lower_clip: float,
-                      flag_value_cols: List[str]) -> pd.DataFrame:
+def run_auto_flagging(
+    df: pd.DataFrame, upper_clip: float, lower_clip: float, flag_value_cols: List[str]
+) -> pd.DataFrame:
     """Flag outliers based on clipping values specified in the config.
 
     For each of the 'flag_cols' columns specified in the developers config, a
     boolean flag is created for the highest values in the in the column, based on
-    the upper_clip percentage, and the lowest non-zero values, based on the 
-    lower_clip percengage (usually the lower clip will be zero, so not effective.) 
+    the upper_clip percentage, and the lowest non-zero values, based on the
+    lower_clip percengage (usually the lower clip will be zero, so not effective.)
     Zero or null values are not included in the flagging process.
 
     A master outlier flag, 'auto_outlier', is created with a value True if any one
     of the other outlier flags is True.
 
     Notes:
-        - Outliering is only done for randomly sampled (rather than 'census') 
+        - Outliering is only done for randomly sampled (rather than 'census')
           data, so flags are only created where column 'seclectiontype' = 'P'.
 
     Args:
@@ -177,8 +184,9 @@ def run_auto_flagging(df: pd.DataFrame,
     for value_col in flag_value_cols:
         # to_numeric is needed to convert strings. However 'coerce' means values that
         # can't be converted are represented by NaNs.
-        #TODO data validation and cleaning should replace the need for 'to_numeric'
-        df[value_col] = pd.to_numeric(df[value_col], errors='coerce')
+        # TODO data validation and cleaning should replace the need for 'to_numeric'
+        # check ticket (RDRP-386)
+        df[value_col] = pd.to_numeric(df[value_col], errors="coerce")
 
         # Call function to add a flag for auto outliers in column value_col
         df = flag_outliers(df, upper_clip, lower_clip, value_col)
@@ -190,11 +198,11 @@ def run_auto_flagging(df: pd.DataFrame,
     df = decide_outliers(df, flag_value_cols)
 
     # log the number of True flags in the master outlier flag column
-    num_flagged = df[df["auto_outlier"]==True]["auto_outlier"].count()
+    num_flagged = df[df["auto_outlier"]]["auto_outlier"].count()
 
-    msg = (f"Outlier flags have been created for {num_flagged} records in total.")
+    msg = f"Outlier flags have been created for {num_flagged} records in total."
     OutlierMainLogger.info(msg)
 
-    OutlierMainLogger.info("Finishing automatic outlier detection.")  
+    OutlierMainLogger.info("Finishing automatic outlier detection.")
 
     return df

--- a/src/outlier_detection/auto_outliers.py
+++ b/src/outlier_detection/auto_outliers.py
@@ -140,7 +140,7 @@ def auto_clipping(df: pd.DataFrame,
     validate_config(upper_clip, lower_clip)
 
     # Specify the value column and the groupby columns for outliers
-    outlier_val_col = "701"
+    outlier_val_col = "709"
 
     df[outlier_val_col] = pd.to_numeric(df[outlier_val_col], errors='coerce')
     groupby_cols = ["period", "cellnumber"]

--- a/src/outlier_detection/auto_outliers.py
+++ b/src/outlier_detection/auto_outliers.py
@@ -1,0 +1,122 @@
+"""Apply outlier detection to the dataset."""
+import logging
+import pandas as pd
+
+OutlierMainLogger = logging.getLogger(__name__)
+
+
+def validate_config(upper_clip: float, lower_clip: float):
+    """Validate the outlier config settings.
+
+    args:
+        upper_clip (float): The percentage for upper clipping as float
+        lower_clip (float): The percentage for lower clipping as float
+
+    raises:
+        ImportError if upper_clip or lower_clip have invalid values
+    """
+    OutlierMainLogger.info(f"Upper clip: {upper_clip}, Lower clip: {lower_clip}")
+
+    if (upper_clip == 0) and (lower_clip == 0):
+        OutlierMainLogger.warning(
+            "upper_clip and lower_clip both zero: "
+            "All auto_outlier flags will be False"
+        )
+    elif (upper_clip < 0) | (lower_clip < 0):
+        OutlierMainLogger.error("upper_clip and lower_clip cannot be negative")
+        raise ImportError
+    elif upper_clip + lower_clip > 1.0:
+        OutlierMainLogger.error("upper_clip and lower_clip must sum to < 1")
+        raise ImportError
+
+
+def outlier_flagging(
+    df: pd.DataFrame,
+    upper_clip: float,
+    lower_clip: float,
+    groupby_cols: list = ["period, cellnumber"],
+    value_col: str = "211",
+):
+    """Create Boolean column to flag outliers.
+
+    args:
+        df (pd.DataFrame): filtered dataframe containing only essential cols
+            and rows used for auto outliers
+        upper_clip (float): The percentage for upper clipping as float
+        lower_clip (float): The percentage for lower clipping as float
+
+    returns:
+        df (pd.DataFrame): The dataframe with a outlier flag column.
+    """
+    lower_band = 0 + lower_clip
+    upper_band = 1 - upper_clip
+
+    quantiles_up = (
+        df.groupby(groupby_cols)
+        .quantile([upper_band], interpolation="nearest")
+        .reset_index()
+    )
+    quantiles_up = quantiles_up.rename(columns={value_col: "upper_band"})[
+        groupby_cols + ["upper_band"]
+    ]
+
+    quantiles_low = (
+        df.groupby(groupby_cols)
+        .quantile([lower_band], interpolation="nearest")
+        .reset_index()
+    )
+    quantiles_low = quantiles_low.rename(columns={value_col: "lower_band"})[
+        groupby_cols + ["lower_band"]
+    ]
+    # quantiles_low.round({'value': 0})
+    df = df.merge(quantiles_up, on=groupby_cols).merge(quantiles_low, on=groupby_cols)
+
+    df["auto_outlier"] = (df[value_col] > df.upper_band) | (
+        df[value_col] < df.lower_band
+    )
+    return df
+
+
+def auto_clipping(df: pd.DataFrame, upper_clip: float = 0.1, lower_clip: float = 0.0):
+    """Flag outliers for quantiles specified in the config.
+
+
+    Calculate the automatic outlier flag (Boolean) in a column
+    called auto_outlier.
+
+    Use values specified in the config file for the upper and lower
+    clipping values.
+
+    Notes:
+        - The value column for the detection of outliers is assumed to be '211'.
+        - Outliering is not applied to 'census' data, so flags are only created
+            where 'seclectiontype' = 'P'.
+
+    Args:
+        df (pd.DataFrame): The main dataset where outliers are to be calculated
+        upper_clip (float): The percentage for upper clipping as float
+        lower_clip (float): The percentage for lower clipping as float
+
+    Returns:
+        df (pd.DataFrame): The full dataset with flag column for outliers.
+    """
+    OutlierMainLogger.info("Starting outlier detection...")
+
+    # Validate the outlier configuration settings
+    validate_config(upper_clip, lower_clip)
+
+    # Specify the value column and the groupby columns for outliers
+    outlier_val_col = "211"
+    df = df.astype({outlier_val_col: float})
+    groupby_cols = ["period", "cellnumber"]
+
+    # Note: selectiontype=='P' doesn't exist in anonymised data!
+
+    # Filter dataframe and select cols needed for outlier flag
+    clipping_df = df[df.selectiontype == "P"][groupby_cols + [outlier_val_col]].copy()
+
+    flagged_df = outlier_flagging(
+        clipping_df, upper_clip, lower_clip, groupby_cols, outlier_val_col
+    )
+
+    return flagged_df

--- a/src/outlier_detection/auto_outliers.py
+++ b/src/outlier_detection/auto_outliers.py
@@ -52,8 +52,8 @@ def outlier_flagging(
     upper_band = 1 - upper_clip
 
     # Note: selectiontype=='P' doesn't exist in anonymised data!
-    filtered_df = df[(df.selectiontype.isin({"P", "L"})) & (df[value_col] > 0)]
-    # filtered_df = df[(df.selectiontype=='P') & (df[value_col] > 0)]
+    filter_cond = (df[value_col] > 0) & (df.selectiontype=='P')
+    filtered_df = df[filter_cond]
 
     quantiles_up = (
         filtered_df[groupby_cols + [value_col]]
@@ -74,17 +74,44 @@ def outlier_flagging(
     quantiles_low = quantiles_low.rename(columns={value_col: "lower_band"})[
         groupby_cols + ["lower_band"]
     ]
-    # quantiles_low.round({'value': 0})
-    df = df.merge(quantiles_up, on=groupby_cols).merge(quantiles_low, on=groupby_cols)
+
+    df = (df.merge(quantiles_up, on=groupby_cols, how='left')
+            .merge(quantiles_low, on=groupby_cols, how='left'))
 
     outlier_cond = (df[value_col] > df.upper_band) | (df[value_col] < df.lower_band)
 
-    df["auto_outlier"] = outlier_cond & df[value_col] > 0
+    # create boolean auto_outlier col based on conditional logic
+    df["auto_outlier"] = outlier_cond & filter_cond
     df = df.drop(["upper_band", "lower_band"], axis=1)
     return df
 
 
-def auto_clipping(df: pd.DataFrame, upper_clip: float = 0.1, lower_clip: float = 0.0):
+def calc_num_outliers(df: pd.DataFrame, outlier_val_col: str):
+    """Calculate and number of outliers flagged.
+    
+    Also calculate the total number of non-zero entries in the 
+    outlier value column.
+
+    args:
+        df (pd.DataFrame): The dataframe used for finding outliers
+        value_col (str): The name of the column outliers are calculated for
+
+    returns:
+        num_flagged (int): The number of flagged outliers
+        tot_nonzero (int): The total number of nonzero entries in the 
+            outlier value column.
+    """
+
+    num_flagged = df[df["auto_outlier"]==True]["auto_outlier"].count()
+
+    tot_nonzero = df[df[outlier_val_col]>0][outlier_val_col].count()
+    
+    return num_flagged, tot_nonzero
+
+
+def auto_clipping(df: pd.DataFrame, 
+                  upper_clip: float = 0.5, 
+                  lower_clip: float = 0.0):
     """Flag outliers for quantiles specified in the config.
 
 
@@ -113,13 +140,22 @@ def auto_clipping(df: pd.DataFrame, upper_clip: float = 0.1, lower_clip: float =
     validate_config(upper_clip, lower_clip)
 
     # Specify the value column and the groupby columns for outliers
-    outlier_val_col = "211"
-    df = df.astype({outlier_val_col: float})
+    outlier_val_col = "701"
+
+    df[outlier_val_col] = pd.to_numeric(df[outlier_val_col], errors='coerce')
     groupby_cols = ["period", "cellnumber"]
 
     # Calculate flags for auto outliers
     flagged_df = outlier_flagging(
         df, upper_clip, lower_clip, groupby_cols, outlier_val_col
     )
+
+    num_flagged, tot_nonzero = calc_num_outliers(flagged_df, outlier_val_col)
+
+    msg = (f"{num_flagged} outliers were detected out of a total of "
+           f"{tot_nonzero} non-zero entries in column {outlier_val_col}")
+
+    OutlierMainLogger.info("Finishing automatic outlier detection.")  
+    OutlierMainLogger.info(msg)
 
     return flagged_df

--- a/src/outlier_detection/outlier_main.py
+++ b/src/outlier_detection/outlier_main.py
@@ -37,7 +37,6 @@ def run_outliers(df: pd.DataFrame, config: dict, write_csv: Callable):
     upper_clip = config["outliers"]["upper_clip"]
     lower_clip = config["outliers"]["lower_clip"]
     df_auto_flagged = auto.auto_clipping(df, upper_clip, lower_clip)
-    print(df_auto_flagged.head())
 
     OutlierMainLogger.info("Finished Auto Outlier Detection.")
 

--- a/src/outlier_detection/outlier_main.py
+++ b/src/outlier_detection/outlier_main.py
@@ -9,7 +9,9 @@ from src.outlier_detection import auto_outliers as auto
 OutlierMainLogger = logging.getLogger(__name__)
 
 
-def run_outliers(df: pd.DataFrame, config: dict, write_csv: Callable):
+def run_outliers(df: pd.DataFrame, 
+                 config: dict, 
+                 write_csv: Callable) -> pd.DataFrame:
     """
     Run the outliering module.
 
@@ -36,11 +38,12 @@ def run_outliers(df: pd.DataFrame, config: dict, write_csv: Callable):
 
     upper_clip = config["outliers"]["upper_clip"]
     lower_clip = config["outliers"]["lower_clip"]
-    df_auto_flagged = auto.auto_clipping(df, upper_clip, lower_clip)
+    df_auto_flagged = auto.auto_flagging(df, upper_clip, lower_clip)
 
     OutlierMainLogger.info("Finished Auto Outlier Detection.")
 
     # output the outlier flags for QA
+    #TODO when working on DAP need to output QA there also.
     if config["global"]["network_or_hdfs"] == "network":
         OutlierMainLogger.info("Starting output of Outlier QA data...")
         folder = config["network_paths"]["outliers_path"]

--- a/src/outlier_detection/outlier_main.py
+++ b/src/outlier_detection/outlier_main.py
@@ -38,7 +38,8 @@ def run_outliers(df: pd.DataFrame,
 
     upper_clip = config["outliers"]["upper_clip"]
     lower_clip = config["outliers"]["lower_clip"]
-    df_auto_flagged = auto.auto_flagging(df, upper_clip, lower_clip)
+    flag_cols = config["outliers"]["flag_cols"]
+    df_auto_flagged = auto.run_auto_flagging(df, upper_clip, lower_clip, flag_cols)
 
     OutlierMainLogger.info("Finished Auto Outlier Detection.")
 

--- a/src/outlier_detection/outlier_main.py
+++ b/src/outlier_detection/outlier_main.py
@@ -1,1 +1,37 @@
 """Main file for the Outlier Detection module."""
+import logging
+import pandas as pd
+
+from src.outlier_detection import auto_outliers as auto
+
+OutlierMainLogger = logging.getLogger(__name__)
+
+
+def run_outliers(df: pd.DataFrame, outlier_config: dict):
+    """
+    Run the outliering module.
+
+    The auto-outlier procedure is applied first, adding a flag column for
+    automatically detected outliers. This is output for the user.
+
+    If a manual outlier file has been supplied by the user, this is read in,
+    and the manually specified outlier flags supercede auto ones.
+
+    The dataset is returned with a final outlier flag column to be used in
+    the estimation module.
+
+    Args:
+        df (pd.DataFrame): The main dataset where outliers are to be calculated.
+        outlier_config (dict): The global configuration settings.
+
+    Returns:
+        df_outliers_applied (pd.DataFrame): The main dataset with a flag column
+            indicating outliers for use the estimation module.
+    """
+    OutlierMainLogger.info("Starting Auto Outlier Detection...")
+
+    upper_clip = outlier_config["upper_clip"]
+    lower_clip = outlier_config["lower_clip"]
+    df_auto_flagged = auto.auto_clipping(df, upper_clip, lower_clip)
+    print(df_auto_flagged.head())
+    OutlierMainLogger.info("Finished Auto Outlier Detection.")

--- a/src/outlier_detection/outlier_main.py
+++ b/src/outlier_detection/outlier_main.py
@@ -16,7 +16,7 @@ def run_outliers(df: pd.DataFrame,
     Run the outliering module.
 
     The auto-outlier procedure is applied first, adding a flag column for
-    automatically detected outliers. This is output for the user.
+    automatically detected outliers. The data is then output for the user.
 
     If a manual outlier file has been supplied by the user, this is read in,
     and the manually specified outlier flags supercede auto ones.

--- a/src/outlier_detection/outlier_main.py
+++ b/src/outlier_detection/outlier_main.py
@@ -1,6 +1,7 @@
 """Main file for the Outlier Detection module."""
 import logging
 import pandas as pd
+from datetime import datetime
 from typing import Callable
 
 from src.outlier_detection import auto_outliers as auto
@@ -37,4 +38,20 @@ def run_outliers(df: pd.DataFrame, config: dict, write_csv: Callable):
     lower_clip = config["outliers"]["lower_clip"]
     df_auto_flagged = auto.auto_clipping(df, upper_clip, lower_clip)
     print(df_auto_flagged.head())
+
     OutlierMainLogger.info("Finished Auto Outlier Detection.")
+
+    # output the outlier flags for QA
+    if config["global"]["network_or_hdfs"] == "network":
+        OutlierMainLogger.info("Starting output of Outlier QA data...")
+        folder = config["network_paths"]["outliers_path"]
+        tdate = datetime.now().strftime("%Y-%m-%d")
+        filename = f"outliers_qa_{tdate}.csv"
+        write_csv(f"{folder}/outliers_qa/{filename}", df_auto_flagged)
+        OutlierMainLogger.info("Finished QA output of outliers data.")
+
+     # read in file for manual outliers
+
+     # update outlier flag column with manual outliers   
+
+    return df_auto_flagged

--- a/src/outlier_detection/outlier_main.py
+++ b/src/outlier_detection/outlier_main.py
@@ -1,13 +1,14 @@
 """Main file for the Outlier Detection module."""
 import logging
 import pandas as pd
+from typing import Callable
 
 from src.outlier_detection import auto_outliers as auto
 
 OutlierMainLogger = logging.getLogger(__name__)
 
 
-def run_outliers(df: pd.DataFrame, outlier_config: dict):
+def run_outliers(df: pd.DataFrame, config: dict, write_csv: Callable):
     """
     Run the outliering module.
 
@@ -22,7 +23,9 @@ def run_outliers(df: pd.DataFrame, outlier_config: dict):
 
     Args:
         df (pd.DataFrame): The main dataset where outliers are to be calculated.
-        outlier_config (dict): The global configuration settings.
+        config (dict): The configuration settings.
+        write_csv (Callable): Function to write to a csv file.
+            This will be the hdfs or network version depending on settings.
 
     Returns:
         df_outliers_applied (pd.DataFrame): The main dataset with a flag column
@@ -30,8 +33,8 @@ def run_outliers(df: pd.DataFrame, outlier_config: dict):
     """
     OutlierMainLogger.info("Starting Auto Outlier Detection...")
 
-    upper_clip = outlier_config["upper_clip"]
-    lower_clip = outlier_config["lower_clip"]
+    upper_clip = config["outliers"]["upper_clip"]
+    lower_clip = config["outliers"]["lower_clip"]
     df_auto_flagged = auto.auto_clipping(df, upper_clip, lower_clip)
     print(df_auto_flagged.head())
     OutlierMainLogger.info("Finished Auto Outlier Detection.")

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -9,6 +9,7 @@ from src._version import __version__ as version
 from src.utils.helpers import Config_settings
 from src.utils.wrappers import logger_creator
 from src.staging.staging_main import run_staging
+from src.outlier_detection.outlier_main import run_outliers
 
 
 MainLogger = logging.getLogger(__name__)
@@ -76,13 +77,14 @@ def run_pipeline(start):
     MainLogger.info("Finished Data Ingest...")
     print(full_responses.sample(10))
 
-    # Outlier detection
+    # Imputation module
 
-    # Data cleaning
+    # Outlier detection module
+    MainLogger.info("Starting Outlier Detection...")
+    outlier_config = config["outliers"]
+    full_responses = run_outliers(full_responses, outlier_config)
 
-    # Data processing: Imputation
-
-    # Data processing: Estimation
+    # Estimation
 
     # Data processing: Regional Apportionment
 

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -81,8 +81,7 @@ def run_pipeline(start):
 
     # Outlier detection module
     MainLogger.info("Starting Outlier Detection...")
-    outlier_config = config["outliers"]
-    full_responses = run_outliers(full_responses, outlier_config)
+    full_responses = run_outliers(full_responses, config, write_csv)
 
     # Estimation
 

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -74,14 +74,15 @@ def run_pipeline(start):
     full_responses = run_staging(
         config, check_file_exists, load_json, read_csv, write_csv
     )
-    MainLogger.info("Finished Data Ingest...")
-    print(full_responses.sample(10))
+    MainLogger.info("Finished Data Ingest.")
 
     # Imputation module
 
     # Outlier detection module
     MainLogger.info("Starting Outlier Detection...")
-    full_responses = run_outliers(full_responses, config, write_csv)
+    outliered_responses = run_outliers(full_responses, config, write_csv)
+    print(outliered_responses.sample(10))
+    MainLogger.info("Finished Outlier module.")
 
     # Estimation
 

--- a/src/staging/staging_main.py
+++ b/src/staging/staging_main.py
@@ -74,6 +74,7 @@ def run_staging(
             raise Exception("The historic data did not load")
 
     # Check data file exists, raise an error if it does not.
+    StagingMainLogger.info("Loading SPP snapshot data...")
     check_file_exists(snapshot_path)
 
     # load and parse the snapshot data json file

--- a/tests/test_outlier_detection/test_auto_outliers.py
+++ b/tests/test_outlier_detection/test_auto_outliers.py
@@ -1,11 +1,11 @@
 from pandas._testing import assert_frame_equal
 from pandas import DataFrame as pandasDF
 
-from src.outlier_detection.auto_outliers import outlier_flagging
+from src.outlier_detection.auto_outliers import flag_outliers
 
 
 class TestOutlierFlagging:
-    """Unit tests for outlier_flagging functtion."""
+    """Unit tests for flag_outliers functtion."""
 
     def create_input_df(self):
         """Create an input dataframe for the test."""
@@ -80,8 +80,8 @@ class TestOutlierFlagging:
         expected_df = pandasDF(data=data, columns=exp_cols)
         return expected_df
 
-    def test_outlier_flagging(self):
-        """Test for outlier_flagging function."""
+    def test_flag_outliers(self):
+        """Test for flag_outliers function."""
         input_df = self.create_input_df()
         expected_df = self.create_expected_df()
 
@@ -89,7 +89,7 @@ class TestOutlierFlagging:
         lower_clip = 0
         groupby_cols: list = ["period", "cellnumber"]
         value_col: str = "value"
-        result_df = outlier_flagging(
+        result_df = flag_outliers(
             input_df, upper_clip, lower_clip, groupby_cols, value_col
         )
 

--- a/tests/test_outlier_detection/test_auto_outliers.py
+++ b/tests/test_outlier_detection/test_auto_outliers.py
@@ -1,7 +1,7 @@
 from pandas._testing import assert_frame_equal
 from pandas import DataFrame as pandasDF
 
-from src.outlier_detection.auto_outliers import flag_outliers
+from src.outlier_detection.auto_outliers import flag_outliers, decide_outliers
 
 
 class TestOutlierFlagging:
@@ -9,7 +9,7 @@ class TestOutlierFlagging:
 
     def create_input_df(self):
         """Create an input dataframe for the test."""
-        input_cols = ["reference", "selectiontype", "period", "cellnumber", "value"]
+        input_cols = ["reference", "selectiontype", "period", "cellnumber", "701"]
 
         data = [
             [1, "P", 2020, 10, 1.1],
@@ -47,8 +47,8 @@ class TestOutlierFlagging:
             "selectiontype",
             "period",
             "cellnumber",
-            "value",
-            "auto_outlier",
+            "701",
+            "701_outlier_flag",
         ]
 
         data = [
@@ -87,10 +87,53 @@ class TestOutlierFlagging:
 
         upper_clip = 0.1
         lower_clip = 0
-        groupby_cols: list = ["period", "cellnumber"]
-        value_col: str = "value"
+        value_col = "701"
         result_df = flag_outliers(
-            input_df, upper_clip, lower_clip, groupby_cols, value_col
+            input_df, upper_clip, lower_clip, value_col
         )
+
+        assert_frame_equal(result_df, expected_df)
+
+
+class TestDecideOutliers:
+    """Unit tests for decide_outliers functtion."""
+
+    def create_input_df(self):
+        """Create an input dataframe for the test."""
+        input_cols = ["reference", "701_outlier_flag", "702_outlier_flag", "703_outlier_flag"]
+
+        data = [
+            [1, True,  False, False],
+            [2, False, False, False],
+            [3, False, True,  False],
+            [4, True,  True,  False],
+            [5, True,  True,  True]
+        ]
+
+        input_df = pandasDF(data=data, columns=input_cols)
+        return input_df
+
+    def create_expected_df(self):
+        """Create an input dataframe for the test."""
+        exp_cols = ["reference", "701_outlier_flag", "702_outlier_flag", "703_outlier_flag", "auto_outlier"]
+
+        data = [
+            [1, True,  False, False, True],
+            [2, False, False, False, False],
+            [3, False, True,  False, True],
+            [4, True,  True,  False, True],
+            [5, True,  True,  True, True]
+        ]
+
+        exp_df = pandasDF(data=data, columns=exp_cols)
+        return exp_df
+
+    def test_decide_outliers(self):
+        """Test for decide_outliers function."""
+        input_df = self.create_input_df()
+        expected_df = self.create_expected_df()
+
+        flag_cols = ["701", "702", "703"]
+        result_df = decide_outliers(input_df, flag_cols)
 
         assert_frame_equal(result_df, expected_df)

--- a/tests/test_outlier_detection/test_auto_outliers.py
+++ b/tests/test_outlier_detection/test_auto_outliers.py
@@ -34,6 +34,7 @@ class TestOutlierFlagging:
             [20, "P", 2020, 20, 3.0],
             [21, "P", 2020, 20, 0.0],
             [22, "P", 2020, 20, 0.0],
+            [23, "C", 2020, 20, 4.0],         
         ]
 
         input_df = pandasDF(data=data, columns=input_cols)
@@ -73,6 +74,7 @@ class TestOutlierFlagging:
             [20, "P", 2020, 20, 3.0, True],
             [21, "P", 2020, 20, 0.0, False],
             [22, "P", 2020, 20, 0.0, False],
+            [23, "C", 2020, 20, 4.0, False],     
         ]
 
         expected_df = pandasDF(data=data, columns=exp_cols)

--- a/tests/test_outlier_detection/test_auto_outliers.py
+++ b/tests/test_outlier_detection/test_auto_outliers.py
@@ -1,0 +1,94 @@
+from pandas._testing import assert_frame_equal
+from pandas import DataFrame as pandasDF
+
+from src.outlier_detection.auto_outliers import outlier_flagging
+
+
+class TestOutlierFlagging:
+    """Unit tests for outlier_flagging functtion."""
+
+    def create_input_df(self):
+        """Create an input dataframe for the test."""
+        input_cols = ["reference", "selectiontype", "period", "cellnumber", "value"]
+
+        data = [
+            [1, "P", 2020, 10, 1.1],
+            [2, "P", 2020, 10, 1.2],
+            [3, "P", 2020, 10, 1.3],
+            [4, "P", 2020, 10, 1.4],
+            [5, "P", 2020, 10, 1.5],
+            [6, "P", 2020, 10, 1.6],
+            [7, "P", 2020, 10, 1.7],
+            [8, "P", 2020, 10, 1.8],
+            [9, "P", 2020, 10, 1.9],
+            [10, "P", 2020, 10, 2.0],
+            [11, "P", 2020, 20, 2.1],
+            [12, "P", 2020, 20, 2.2],
+            [13, "P", 2020, 20, 2.3],
+            [14, "P", 2020, 20, 2.4],
+            [15, "P", 2020, 20, 2.5],
+            [16, "P", 2020, 20, 2.6],
+            [17, "P", 2020, 20, 2.7],
+            [18, "P", 2020, 20, 2.8],
+            [19, "P", 2020, 20, 2.9],
+            [20, "P", 2020, 20, 3.0],
+            [21, "P", 2020, 20, 0.0],
+            [22, "P", 2020, 20, 0.0],
+        ]
+
+        input_df = pandasDF(data=data, columns=input_cols)
+        return input_df
+
+    def create_expected_df(self):
+        """Create dataframe for the expected output of the test."""
+        exp_cols = [
+            "reference",
+            "selectiontype",
+            "period",
+            "cellnumber",
+            "value",
+            "auto_outlier",
+        ]
+
+        data = [
+            [1, "P", 2020, 10, 1.1, False],
+            [2, "P", 2020, 10, 1.2, False],
+            [3, "P", 2020, 10, 1.3, False],
+            [4, "P", 2020, 10, 1.4, False],
+            [5, "P", 2020, 10, 1.5, False],
+            [6, "P", 2020, 10, 1.6, False],
+            [7, "P", 2020, 10, 1.7, False],
+            [8, "P", 2020, 10, 1.8, False],
+            [9, "P", 2020, 10, 1.9, False],
+            [10, "P", 2020, 10, 2.0, True],
+            [11, "P", 2020, 20, 2.1, False],
+            [12, "P", 2020, 20, 2.2, False],
+            [13, "P", 2020, 20, 2.3, False],
+            [14, "P", 2020, 20, 2.4, False],
+            [15, "P", 2020, 20, 2.5, False],
+            [16, "P", 2020, 20, 2.6, False],
+            [17, "P", 2020, 20, 2.7, False],
+            [18, "P", 2020, 20, 2.8, False],
+            [19, "P", 2020, 20, 2.9, False],
+            [20, "P", 2020, 20, 3.0, True],
+            [21, "P", 2020, 20, 0.0, False],
+            [22, "P", 2020, 20, 0.0, False],
+        ]
+
+        expected_df = pandasDF(data=data, columns=exp_cols)
+        return expected_df
+
+    def test_outlier_flagging(self):
+        """Test for outlier_flagging function."""
+        input_df = self.create_input_df()
+        expected_df = self.create_expected_df()
+
+        upper_clip = 0.1
+        lower_clip = 0
+        groupby_cols: list = ["period", "cellnumber"]
+        value_col: str = "value"
+        result_df = outlier_flagging(
+            input_df, upper_clip, lower_clip, groupby_cols, value_col
+        )
+
+        assert_frame_equal(result_df, expected_df)


### PR DESCRIPTION
## Pull Request submission

Creation of functions to detect and apply automatically detected outliers.

This adapted code written by GZ using the pandas quantile function.

The script `auto_outliers.py` is called from `outlier_main.py` and: 
-  validates `clip_upper` and `clip_lower` parameters from the configuration
-  calculates the outliers based on the parameters supplied
- outputs the number of outliers in the outlier_val_col column, along with the total number of non-zero entries.

A unit test is given for the outlier calculation function.

NOTE: We're still waiting for confirmation about which column the outliers should be detected in, currently the outlier_val_col is set to '701' in the code, this column is the total expenditure for Civil in the short forms, the short form equivalent of q211.

#### Closes or fixes

* Detail the ticket(s) you are closing with this PR
Closes #302 and #297

#### Code

- [x] **Code runs** The code runs on my machine 
- [ ] **Conflicts resolved** There are no conflicts (I have performed a rebase if necessary)
- [ ] **Requirements** My/our code functions according to the requirements of the ticket
- [ ] **Dependencies** I have updated the environment yaml so it includes any new libraries I have used
- [ ] **Configuration file updated** any high level parameters that the user may interact with have been put into the config file (and imported to the script)
- [ ] **Clean Code**
    - [ ] Code is as [PEP 8]([url](https://peps.python.org/pep-0008/)) compliant as I can humanly make it
    - [ ] Code passess flake8 linting check
    - [ ] Code adheres to [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)
- [ ] **Type hints** All new functions have [type hints ](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html)


#### Documentation

Any new code includes all the following forms of documentation:

- [x] **Function Documentation** Docstrings within the function(s')/methods have been created
    - [x] Includes `Args` and `returns` for all major functions
    - [ ] The docstring details data types
- [ ] **Updated Documentation**: User and/or developer working doc has been updated

#### Data
- [ ] All data needed to run this script is available in Dev/Test
- [ ] All data is excluded from this pull request
- [ ] Secrets checker pre-commit passes

#### Testing
- [ ] **Unit tests** Unit tests have been created and are passing _or a new ticket to create tests has been created_

---

# Peer Review Section

- [x] All requirements install from (updated) `environment.yaml`
- [ ] Documentation has been created and is clear - **check the working document**
- [x] Doctrings ([Google format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)) have been created and accurately describe the function's functionality
- [x] Unit tests pass, or if not present _a new ticket to create tests has been created_
- [x] **Code runs** The code runs on reviewer's machine and/or CDSW

#### Final approval (post-review)

The author has responded to my review and made changes to my satisfaction.
- [ ] **I recommend merging this request.**

---

### Review comments

*Insert detailed comments here!*

These might include, but not exclusively:

- bugs that need fixing (does it work as expected? and does it work with other code
  that it is likely to interact with?)
- alternative methods (could it be written more efficiently or with more clarity?)
- documentation improvements (does the documentation reflect how the code actually works?)
- additional tests that should be implemented (do the tests effectively assure that it
  works correctly?)
- code style improvements (could the code be written more clearly?)
- Do the changes represent a change in functionality so the version number should increase? Start a discussion if so.
- As a review you can generates the same outputs from running the code

Your suggestions should be tailored to the code that you are reviewing.
Be critical and clear, but not mean. Ask questions and set actions.
