### PR TITLE
RDRP-669: statusencoded/CORA bug fixes

### DIFF
--- a/config/construction_schema.toml
+++ b/config/construction_schema.toml
@@ -60,7 +60,7 @@ Possible_Categorical_Values = [100, 200, 201, 210, 211, 301, 302, 303, 304, 305,
 
 [receiptdate]
 Description = "Datetime format = %Y-%m-%d %H:%M:%S.%f+00"
-Deduced_Data_Type = "datetime64ns"
+Deduced_Data_Type = "datetime64[ns]"
 Nullable = false
 Current_Data_Type = ["None","str"]
 Length = "nan"
@@ -360,7 +360,7 @@ Possible_Categorical_Values = ["WW", "BB", "FE", "GG", "JG", "HH", "ED", "KJ", "
 
 [birthdate]
 Description = "Datetime format = format=%d/%m/%Y"
-Deduced_Data_Type = "datetime64ns"
+Deduced_Data_Type = "datetime64[ns]"
 Nullable = false
 Current_Data_Type = "str"
 Length = "nan"
@@ -420,7 +420,7 @@ Possible_categorical_Values = ["nan"]
 
 [lastupdateddate]
 Description = "Datetime format = %Y-%m-%d %H:%M:%S.%f+00"
-Deduced_Data_Type = "datetime64ns"
+Deduced_Data_Type = "datetime64[ns]"
 Nullable = false
 Current_Data_Type = ["None","str"]
 Length = "nan"

--- a/config/contributors_schema.toml
+++ b/config/contributors_schema.toml
@@ -50,7 +50,7 @@ Possible_Categorical_Values = ["Clear", "Clear - overridden", "Form saved", "Cle
 
 [statusencoded]
 Description = "nan"
-Deduced_Data_Type = "Int64"
+Deduced_Data_Type = "category"
 Nullable = false
 Current_Data_Type = "Int64"
 Length = 3
@@ -60,7 +60,7 @@ Possible_Categorical_Values = [100, 200, 201, 210, 211, 301, 302, 303, 304, 305,
 
 [receiptdate]
 Description = "Datetime format = %Y-%m-%d %H:%M:%S.%f+00"
-Deduced_Data_Type = "datetime64ns"
+Deduced_Data_Type = "datetime64[ns]"
 Nullable = false
 Current_Data_Type = ["None","str"]
 Length = "nan"
@@ -360,7 +360,7 @@ Possible_Categorical_Values = ["WW", "BB", "FE", "GG", "JG", "HH", "ED", "KJ", "
 
 [birthdate]
 Description = "Datetime format = format=%d/%m/%Y"
-Deduced_Data_Type = "datetime64ns"
+Deduced_Data_Type = "datetime64[ns]"
 Nullable = false
 Current_Data_Type = "str"
 Length = "nan"
@@ -430,7 +430,7 @@ Possible_Categorical_Values = ["ingestion"]
 
 [createddate]
 Description = "Datetime format = %Y-%m-%d %H:%M:%S.%f+00"
-Deduced_Data_Type = "datetime64ns"
+Deduced_Data_Type = "datetime64[ns]"
 Nullable = false
 Current_Data_Type = "str"
 Length = ">=1"
@@ -450,7 +450,7 @@ Possible_Categorical_Values = ["data_migration", "Cheri", "Adela", "David"]
 
 [lastupdateddate]
 Description = "Datetime format = %Y-%m-%d %H:%M:%S.%f+00"
-Deduced_Data_Type = "datetime64ns"
+Deduced_Data_Type = "datetime64[ns]"
 Nullable = false
 Current_Data_Type = ["None","str"]
 Length = "nan"

--- a/config/long_response.toml
+++ b/config/long_response.toml
@@ -80,7 +80,7 @@ Possible_Categorical_Values = ["ingestion"]
 
 [createddate]
 Description = "Datetime format = %Y-%m-%d %H:%M:%S.%f+00"
-Deduced_Data_Type = "datetime64ns"
+Deduced_Data_Type = "datetime64[ns]"
 Nullable = false
 Current_Data_Type = "str"
 Length = ">=1"
@@ -100,7 +100,7 @@ Possible_Categorical_Values = ["data_migration", "Cheri", "Adela", "David"]
 
 [lastupdateddate]
 Description = "Datetime format = %Y-%m-%d %H:%M:%S.%f+00"
-Deduced_Data_Type = "datetime64ns"
+Deduced_Data_Type = "datetime64[ns]"
 Nullable = false
 Current_Data_Type = ["None","str"]
 Length = "nan"

--- a/config/output_schemas/full_responses_imputed_schema.toml
+++ b/config/output_schemas/full_responses_imputed_schema.toml
@@ -564,7 +564,7 @@ Deduced_Data_Type = "object"
 
 [statusencoded]
 old_name = "statusencoded"
-Deduced_Data_Type = "int64"
+Deduced_Data_Type = "category"
 
 [postcodes_harmonised]
 old_name = "postcodes_harmonised"

--- a/config/output_schemas/manual_trimming_qa_schema.toml
+++ b/config/output_schemas/manual_trimming_qa_schema.toml
@@ -216,7 +216,7 @@ Deduced_Data_Type = "object"
 
 [statusencoded]
 old_name = "statusencoded"
-Deduced_Data_Type = "int64"
+Deduced_Data_Type = "category"
 
 [postcodes_harmonised]
 old_name = "postcodes_harmonised"

--- a/config/output_schemas/status_filtered_qa_schema.toml
+++ b/config/output_schemas/status_filtered_qa_schema.toml
@@ -568,7 +568,7 @@ Deduced_Data_Type = "object"
 
 [statusencoded]
 old_name = "statusencoded"
-Deduced_Data_Type = "int64"
+Deduced_Data_Type = "category"
 
 [postcodes_harmonised]
 old_name = "postcodes_harmonised"

--- a/src/developer_config.yaml
+++ b/src/developer_config.yaml
@@ -11,7 +11,7 @@ global:
   load_updated_snapshot: False # Whether to load the updated snapshots for amendments and additions
   load_ni_data: False
   load_historic_data: False
-  run_construction: True
+  run_construction: False
   run_ni_construction: False
   load_manual_outliers: False
   load_manual_imputation: False

--- a/src/outputs/map_output_cols.py
+++ b/src/outputs/map_output_cols.py
@@ -128,8 +128,8 @@ def create_cora_status_col(df, main_col="statusencoded"):
         df: main data with cora status column added
     """
     # Create hardcoded dictionary for mapping
-    status_before = [100, 101, 102, 200, 201, 210, 211, 302, 303, 304, 309]
-    status_after = [200, 100, 1000, 400, 500, 600, 800, 1200, 1300, 900, 1400]
+    status_before = ["100", "101", "102", "200", "201", "210", "211", "302", "303", "304", "309"]
+    status_after = ["200", "100", "1000", "400", "500", "600", "800", "1200", "1300", "900", "1400"]
 
     cora_dict = dict(zip(status_before, status_after))
 


### PR DESCRIPTION
Fixed the bugs that had stopped the develop pipeline from working, and CORA statuses not being mapped correctly.
Changed the statusencoded schema back to category (which stops the error in TMI), and changed the CORA dictionary to strings (which allows statuses to be mapped correctly and appear in outputs).

Also small fix to the datetime64[ns] in schemas to allow it to run (needs square brackets).

This has been tested with and without the feather.

 