### PR TITLE
Update to construction schema

### DIFF
--- a/config/construction_schema.toml
+++ b/config/construction_schema.toml
@@ -1563,3 +1563,13 @@ Length = "nan"
 Min_values = "nan"
 Max_values = "nan"
 Possible_categorical_Values = ["nan"]
+
+[short_to_long]
+Description = "nan"
+Deduced_Data_Type = "boolean"
+Nullable = true
+Current_Data_Type = "str"
+Length = "nan"
+Min_values = "nan"
+Max_values = "nan"
+Possible_categorical_Values = ["nan"]

--- a/config/construction_schema.toml
+++ b/config/construction_schema.toml
@@ -430,7 +430,7 @@ Possible_categorical_Values = ["nan"]
 
 [instance]
 Description = "nan"
-Deduced_Data_Type = "float64"
+Deduced_Data_Type = "Int64"
 Nullable = "nan"
 Current_Data_Type = "object"
 Length = "nan"

--- a/src/construction/construction.py
+++ b/src/construction/construction.py
@@ -87,7 +87,8 @@ def run_construction(
     if not is_northern_ireland:
 
         # Convert formtype to "0001" or "0006" (NI doesn't have a formtype until outputs)
-        construction_df["formtype"] = construction_df["formtype"].apply(convert_formtype)
+        if "formtype" in construction_df.columns:
+            construction_df["formtype"] = construction_df["formtype"].apply(convert_formtype)
 
         # Prepare the short to long form constructions, if any (N/A to NI)
         if "short_to_long" in construction_df.columns:


### PR DESCRIPTION
Resetting the instance schema to Int64 in construction - it was changed to float in the last version, however this was causing problems for the index/.update as snapshot schema was Int64 so was not matching.
Also pushed for review on DAP

24/01: added an if statement to the formtype convert function.  Dan tried a postcode only construction file, and because formtype col dropped, it caused an error.  This is running correctly in my profile space on DAP.
