### PR TITLE
649 imputation class threshold for MoR

### DIFF
--- a/src/developer_config.yaml
+++ b/src/developer_config.yaml
@@ -23,7 +23,7 @@ global:
   # Output settings
   output_full_responses: False
   output_ni_full_responses: False
-  output_imputation_qa: False
+  output_imputation_qa: True
   output_auto_outliers: False
   output_outlier_qa : False
   output_estimation_qa: False
@@ -155,6 +155,7 @@ imputation:
   upper_trim_perc: 15
   trim_threshold: 10 # trimming will only occur on classes strictly larger than this value
   sf_expansion_threshold: 3 # default is 3: the minimum viable imputation class size for short form imputation
+  mor_threshold: 3 # default is 3: the minimum viable imputation class size for MoR imputation
   lf_target_vars:
     - "211"
     - "305"

--- a/src/imputation/MoR.py
+++ b/src/imputation/MoR.py
@@ -47,10 +47,11 @@ def run_mor(df, backdata, impute_vars, lf_target_vars, config):
     )
     # Calculate totals as with TMI
     carried_forwards_df = calculate_totals(carried_forwards_df)
-    return (
-        pd.concat([remainder_df, carried_forwards_df]).reset_index(drop=True),
-        links_df,
-    )
+
+    imputed_df = pd.concat([remainder_df, carried_forwards_df]).reset_index(drop=True)
+    imputed_df = imputed_df.drop("cf_group_size", axis=1)
+
+    return imputed_df, links_df
 
 
 def mor_preprocessing(df, backdata):
@@ -157,7 +158,7 @@ def carry_forwards(df, backdata, impute_vars):
         if (column.endswith("_prev"))
         & (re.search("(.*)_prev|.*", column).group(1) not in impute_vars)
     ]
-    to_drop += ["_merge", "cf_group_size"]
+    to_drop += ["_merge"]
     df = df.drop(to_drop, axis=1)
     return df
 

--- a/src/imputation/MoR.py
+++ b/src/imputation/MoR.py
@@ -223,6 +223,16 @@ def calculate_links(gr_df, target_vars, config):
     return gr_df[column_order].reset_index(drop=True)
 
 
+def get_threshold_value(config: dict) -> int:
+    """Read, validate and return threshold value from the config."""
+    threshold_num = config["imputation"]["mor_threshold"]
+    if (type(threshold_num) == int) & (threshold_num >=0):
+        return threshold_num
+    else:
+        raise Exception("The variable 'mor_threshold' in the 'imputation' section "
+                        "of the config must be zero or a positive integer.")
+        
+
 def group_calc_link(group, target_vars, config):
     """Apply the MoR method to each group
 
@@ -244,8 +254,11 @@ def group_calc_link(group, target_vars, config):
             .values
         )
 
-        # If there are non-null, non-zero values in the group calculate the mean
-        if sum(~group[f"{var}_gr_trim"] & non_null_mask) != 0:
+        
+        threshold_num = get_threshold_value(config)
+        
+        # If there are non-null, non-zero values in the group calculate the mean        
+        if sum(~group[f"{var}_gr_trim"] & non_null_mask) <= threshold_num:
             group[f"{var}_link"] = group.loc[
                 ~group[f"{var}_gr_trim"] & non_null_mask, f"{var}_gr"
             ].mean()

--- a/src/imputation/imputation_helpers.py
+++ b/src/imputation/imputation_helpers.py
@@ -245,6 +245,7 @@ def tidy_imputation_dataframe(
 
     to_drop += ["200_original", "pg_sic_class", "empty_pgsic_group", "empty_pg_group"]
     to_drop += ["200_imp_marker", "211_trim", "305_trim", "manual_trim"]
+    
     df = df.drop(columns=to_drop)
 
     # Keep only imputed records and clear ("R")


### PR DESCRIPTION
## Pull Request submission

In mean of ratios, created a configurable threshold value for the size of an imputation class, based on the number of non-zero values in col 211.

If the imputation class is below the threshold, a fall-back to the carry forwards method is used instead.

Note for reviewer: An extra column, cf_group_size has been added to the links QA output csv, this shows the size of the group, and if it's below the threshold chosen (I suggest 3 for the network, so you have examples below and above) then the link should be 1.  Please could you check that the sizes in that column are correct? The number of positive values in the column 211 for that imputation class. (I have checked and it seems ok)

Another fix: previously we filled nulls with zeros for all carry forward rows, this time we only fill nulls with zeros where column 211 is not null. This means that "post code only" and instance 0 rows will remain null for the key variables.
 

#### Closes or fixes

* Detail the ticket(s) you are closing with this PR
Closes #649


#### Code

- [ ] **Code runs** The code runs on my machine and/or CDSW
- [ ] **Conflicts resolved** There are no conflicts (I have performed a rebase if necessary)
- [ ] **Requirements** My/our code functions according to the requirements of the ticket
- [ ] **Dependencies** I have updated the environment yaml so it includes any new libraries I have used
- [ ] **Configuration file updated** any high level parameters that the user may interact with have been put into the config file (and imported to the script)
- [ ] **Clean Code**
    - [ ] Code is as [PEP 8]([url](https://peps.python.org/pep-0008/)) compliant as I can humanly make it
    - [ ] Code passess flake8 linting check
    - [ ] Code adheres to [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)
- [ ] **Type hints** All new functions have [type hints ](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html)


#### Documentation

Any new code includes all the following forms of documentation:

- [ ] **Function Documentation** Docstrings within the function(s')/methods have been created
    - [ ] Includes `Args` and `returns` for all major functions
    - [ ] The docstring details data types
- [ ] **Updated Documentation**: User and/or developer working doc has been updated

#### Data
- [ ] All data needed to run this script is available in Dev/Test
- [ ] All data is excluded from this pull request
- [ ] Secrets checker pre-commit passes

#### Testing
- [ ] **Unit tests** Unit tests have been created and are passing _or a new ticket to create tests has been created_

---

# Peer Review Section

- [ ] All requirements install from (updated) `environment.yaml`
- [ ] Documentation has been created and is clear - **check the working document**
- [ ] Doctrings ([Google format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)) have been created and accurately describe the function's functionality
- [ ] Unit tests pass, or if not present _a new ticket to create tests has been created_
- [ ] **Code runs** The code runs on reviewer's machine and/or CDSW

#### Final approval (post-review)

The author has responded to my review and made changes to my satisfaction.
- [ ] **I recommend merging this request.**

---

### Review comments

*Insert detailed comments here!*

These might include, but not exclusively:

- bugs that need fixing (does it work as expected? and does it work with other code
  that it is likely to interact with?)
- alternative methods (could it be written more efficiently or with more clarity?)
- documentation improvements (does the documentation reflect how the code actually works?)
- additional tests that should be implemented (do the tests effectively assure that it
  works correctly?)
- code style improvements (could the code be written more clearly?)
- Do the changes represent a change in functionality so the version number should increase? Start a discussion if so.
- As a review you can generates the same outputs from running the code

Your suggestions should be tailored to the code that you are reviewing.
Be critical and clear, but not mean. Ask questions and set actions.
