### PR TITLE
RDRP-667: short to long construction bug fix

### DIFF
--- a/src/construction/construction.py
+++ b/src/construction/construction.py
@@ -175,25 +175,24 @@ def run_construction(
 
 def prepare_short_to_long(updated_snapshot_df, construction_df):
     """Create addional instances for short to long construction"""
-    # Check which references are going to converted to long forms
-    short_to_long_refs = construction_df.loc[
+
+    # Check which references are going to be converted to long forms
+    # and how many instances they have
+    ref_count = construction_df.loc[
         construction_df["short_to_long"] == True, "reference"
-    ].unique()
+    ].value_counts()
+
     # Create conversion df
-    short_to_long_df = updated_snapshot_df[
-        updated_snapshot_df["reference"].isin(short_to_long_refs)
-    ]
+    short_to_long_df = updated_snapshot_df[updated_snapshot_df["reference"].isin(ref_count.index)]
 
-    # Copy instance 0 record to create instance 1 and instance 2
-    short_to_long_df1 = short_to_long_df.copy()
-    short_to_long_df1["instance"] = 1
-    short_to_long_df2 = short_to_long_df.copy()
-    short_to_long_df2["instance"] = 2
+    # For every short_to_long reference, this copies the instance 0 the relevant number of times,
+    # updating to the corresponding instance number
+    for index, value in ref_count.items():
+        for instance in range(1, value):
+            short_to_long_df_instance = short_to_long_df.loc[short_to_long_df["reference"] == index].copy()
+            short_to_long_df_instance["instance"] = instance
+            updated_snapshot_df = pd.concat([updated_snapshot_df, short_to_long_df_instance])
 
-    # Add new instances to the updated snapshot df
-    updated_snapshot_df = pd.concat(
-        [updated_snapshot_df, short_to_long_df1, short_to_long_df2]
-    )
     return updated_snapshot_df
 
 

--- a/src/construction/construction.py
+++ b/src/construction/construction.py
@@ -86,9 +86,12 @@ def run_construction(
     # Run GB specific actions
     if not is_northern_ireland:
 
-        # Convert formtype to "0001" or "0006" (NI doesn't have a formtype until outputs)
+        # Convert formtype to "0001" or "0006"
+        # NI doesn't have a formtype until outputs
         if "formtype" in construction_df.columns:
-            construction_df["formtype"] = construction_df["formtype"].apply(convert_formtype)
+            construction_df["formtype"] = construction_df["formtype"].apply(
+                convert_formtype
+            )
 
         # Prepare the short to long form constructions, if any (N/A to NI)
         if "short_to_long" in construction_df.columns:
@@ -183,15 +186,22 @@ def prepare_short_to_long(updated_snapshot_df, construction_df):
     ].value_counts()
 
     # Create conversion df
-    short_to_long_df = updated_snapshot_df[updated_snapshot_df["reference"].isin(ref_count.index)]
+    short_to_long_df = updated_snapshot_df[
+        updated_snapshot_df["reference"].isin(ref_count.index)
+    ]
 
-    # For every short_to_long reference, this copies the instance 0 the relevant number of times,
+    # For every short_to_long reference,
+    # this copies the instance 0 the relevant number of times,
     # updating to the corresponding instance number
     for index, value in ref_count.items():
         for instance in range(1, value):
-            short_to_long_df_instance = short_to_long_df.loc[short_to_long_df["reference"] == index].copy()
+            short_to_long_df_instance = short_to_long_df.loc[
+                short_to_long_df["reference"] == index
+            ].copy()
             short_to_long_df_instance["instance"] = instance
-            updated_snapshot_df = pd.concat([updated_snapshot_df, short_to_long_df_instance])
+            updated_snapshot_df = pd.concat(
+                [updated_snapshot_df, short_to_long_df_instance]
+            )
 
     return updated_snapshot_df
 
@@ -200,7 +210,9 @@ def convert_formtype(formtype_value):
     if pd.notnull(formtype_value):
         if formtype_value == "1" or formtype_value == "1.0" or formtype_value == "0001":
             return "0001"
-        elif formtype_value == "6" or formtype_value == "6.0" or formtype_value == "0006":
+        elif (
+            formtype_value == "6" or formtype_value == "6.0" or formtype_value == "0006"
+        ):
             return "0006"
         else:
             return None

--- a/src/developer_config.yaml
+++ b/src/developer_config.yaml
@@ -23,7 +23,7 @@ global:
   # Output settings
   output_full_responses: False
   output_ni_full_responses: False
-  output_imputation_qa: True
+  output_imputation_qa: False
   output_auto_outliers: False
   output_outlier_qa : False
   output_estimation_qa: False


### PR DESCRIPTION
Have updated the `prep_short_to_long()` function, so that it reads the number of instances required, and creates the correct number by copying the instance 0 (updating `instance` for each instance). 
Added an example with 5 instances in the test construction file.

A few formatting changes from the pre-commit too
