### PR TITLE
RDRP-681:  NI form_status in TAU bug fix

### DIFF
--- a/src/developer_config.yaml
+++ b/src/developer_config.yaml
@@ -9,7 +9,7 @@ global:
   # Staging and validation settings
   postcode_csv_check: False
   load_updated_snapshot: False # Whether to load the updated snapshots for amendments and additions
-  load_ni_data: False
+  load_ni_data: True
   load_historic_data: False
   run_construction: False
   run_ni_construction: False
@@ -22,7 +22,7 @@ global:
   apportion_sites: True
   # Output settings
   output_full_responses: False
-  output_ni_full_responses: False
+  output_ni_full_responses: True
   output_imputation_qa: False
   output_auto_outliers: False
   output_outlier_qa : False
@@ -31,8 +31,8 @@ global:
   output_long_form: False
   output_short_form: False
   output_gb_sas: False
-  output_ni_sas: False
-  output_tau: False
+  output_ni_sas: True
+  output_tau: True
   output_intram_by_pg: False
   output_intram_by_itl1: False
   output_intram_by_civil_defence: False

--- a/src/outputs/form_output_prep.py
+++ b/src/outputs/form_output_prep.py
@@ -49,9 +49,7 @@ def form_output_prep(
 
         # Update column 201 (currently PG numeric) to alpha-numeric, mapping from SIC.
         ni_full_responses = run_pg_conversion(
-            ni_full_responses, 
-            pg_num_alpha, 
-            sic_pg_num
+            ni_full_responses, pg_num_alpha, sic_pg_num
         )
 
         # outputs_df = pd.concat([outputs_df, ni_full_responses])

--- a/src/outputs/map_output_cols.py
+++ b/src/outputs/map_output_cols.py
@@ -137,8 +137,14 @@ def create_cora_status_col(df, main_col="statusencoded"):
 
     cora_dict = dict(zip(status_before, status_after))
 
-    # Create a new column by mapping values from main_col using the cora_dict
-    df["form_status"] = df[main_col].map(cora_dict)
+    # Create a new column, if required, and map values from main_col
+    # using the cora_dict.  NI already have form_status,
+    # so it only deals with rows with a value in the main col
+    if "form_status" not in df.columns:
+        df["form_status"] = None
+    df.loc[df["form_status"].isnull(), "form_status"] = (
+        df.loc[df["form_status"].isnull(), main_col].map(cora_dict)
+    )
 
     return df
 

--- a/src/outputs/map_output_cols.py
+++ b/src/outputs/map_output_cols.py
@@ -142,9 +142,9 @@ def create_cora_status_col(df, main_col="statusencoded"):
     # so it only deals with rows with a value in the main col
     if "form_status" not in df.columns:
         df["form_status"] = None
-    df.loc[df["form_status"].isnull(), "form_status"] = (
-        df.loc[df["form_status"].isnull(), main_col].map(cora_dict)
-    )
+    df.loc[df["form_status"].isnull(), "form_status"] = df.loc[
+        df["form_status"].isnull(), main_col
+    ].map(cora_dict)
 
     return df
 


### PR DESCRIPTION
The `form_status` is being given to NI data in `form_output_prep.py`, so it can be passed directly to NI SAS.  However, in the TAU output, the `form_status` for GB data is being mapped from `statusencoded` - because NI data doesn't have a `statusencoded` the `form_status` was being overwritten with a null

Have changed the code in `create_cora_status_col()` so that mapping only occurs in the rows where `form_status` is null, which retains the NI form_status.  Because the function is also used by GB SAS, which will not have the NI data and so no `form_status` column, it checks if the column exists and adds it before the mapping function to allow it to work. 
