### PR TITLE
RDRP-688: No R&D in GB SAS

### DIFF
--- a/src/outputs/gb_sas.py
+++ b/src/outputs/gb_sas.py
@@ -35,9 +35,6 @@ def output_gb_sas(
     paths = config[f"{NETWORK_OR_HDFS}_paths"]
     output_path = paths["output_path"]
 
-    # Filter out records that answer "no R&D"
-    df = df.copy().loc[~(df["604"] == "No")]
-
     # Filter regions for GB only
     df1 = df.copy().loc[df["region"].isin(regions()["GB"])]
 

--- a/src/outputs/gb_sas.py
+++ b/src/outputs/gb_sas.py
@@ -35,6 +35,9 @@ def output_gb_sas(
     paths = config[f"{NETWORK_OR_HDFS}_paths"]
     output_path = paths["output_path"]
 
+    # Filter out records that answer "no R&D"
+    df = df.copy().loc[~(df["604"] == "No")]
+
     # Filter regions for GB only
     df1 = df.copy().loc[df["region"].isin(regions()["GB"])]
 

--- a/src/outputs/outputs_helpers.py
+++ b/src/outputs/outputs_helpers.py
@@ -102,6 +102,7 @@ def create_period_year(df: pd.DataFrame) -> pd.DataFrame:
     """
 
     # Extracted the year from period and crated new columns 'period_year'
+    df = df.copy()
     df["period_year"] = df["period"].astype("str").str[:4]
     df["period_year"] = df["period_year"].apply(pd.to_numeric, errors="coerce")
 

--- a/src/outputs/outputs_main.py
+++ b/src/outputs/outputs_main.py
@@ -101,8 +101,8 @@ def run_outputs(
         OutputMainLogger.info("Finished long form output.")
 
     # Filter out records that answer "no R&D" for all subsequent outputs
-    tau_outputs_df = tau_outputs_df.copy().loc[~(df["604"] == "No")]
-    outputs_df = outputs_df.copy().loc[~(df["604"] == "No")]
+    tau_outputs_df = tau_outputs_df.copy().loc[~(tau_outputs_df["604"] == "No")]
+    outputs_df = outputs_df.copy().loc[~(outputs_df["604"] == "No")]
 
     # Running TAU output
     if config["global"]["output_tau"]:

--- a/src/outputs/outputs_main.py
+++ b/src/outputs/outputs_main.py
@@ -57,7 +57,7 @@ def run_outputs(
         civil_defence_detailed (pd.DataFrame): Detailed descriptons of civil/defence
         sic_division_detailed (pd.DataFrame): Detailed descriptons of SIC divisions
         pg_num_alpha (pd.DataFrame): Mapper for product group conversions (num to alpha)
-        sic_pg_num (pd.DataFrame): Mapper for product group conversions 
+        sic_pg_num (pd.DataFrame): Mapper for product group conversions
     """
 
     (
@@ -99,6 +99,10 @@ def run_outputs(
             ultfoc_mapper,
         )
         OutputMainLogger.info("Finished long form output.")
+
+    # Filter out records that answer "no R&D" for all subsequent outputs
+    tau_outputs_df = tau_outputs_df.copy().loc[~(df["604"] == "No")]
+    outputs_df = outputs_df.copy().loc[~(df["604"] == "No")]
 
     # Running TAU output
     if config["global"]["output_tau"]:

--- a/src/outputs/tau.py
+++ b/src/outputs/tau.py
@@ -34,9 +34,6 @@ def output_tau(
     paths = config[f"{NETWORK_OR_HDFS}_paths"]
     output_path = paths["output_path"]
 
-    # Filter out records that answer "no R&D"
-    df = df.copy().loc[~(df["604"] == "No")]
-
     # Filter out instance 0
     df = df.copy().loc[df.instance != 0]
 

--- a/src/outputs/tau.py
+++ b/src/outputs/tau.py
@@ -34,9 +34,6 @@ def output_tau(
     paths = config[f"{NETWORK_OR_HDFS}_paths"]
     output_path = paths["output_path"]
 
-    # Filter out instance 0
-    df = df.copy().loc[df.instance != 0]
-
     # Prepare the columns needed for outputs:
 
     # Join foriegn ownership column using ultfoc mapper


### PR DESCRIPTION
There were 'No R&D' (`604` = No) in the GB SAS output.  There is a filter in the `form_output_prep()`, but it is only taking out records with `211` > 0.  

There is now an explicit filter at the beginning of GB SAS (so we don't lose these records elsewhere) that takes out `604` = No. This is already present in the TAU output.