### PR TITLE
RDRP-671: Period year for SAS & TAU outputs

### DIFF
--- a/config/output_schemas/gb_sas_schema.toml
+++ b/config/output_schemas/gb_sas_schema.toml
@@ -3,7 +3,7 @@ old_name = "reference"
 Deduced_Data_Type = "Int64"
 
 [period]
-old_name = "period"
+old_name = "period_year"
 Deduced_Data_Type = "Int64"
 
 [entref]

--- a/config/output_schemas/ni_sas_schema.toml
+++ b/config/output_schemas/ni_sas_schema.toml
@@ -3,7 +3,7 @@ old_name = "reference"
 Deduced_Data_Type = "Int64"
 
 [period]
-old_name = "period"
+old_name = "period_year"
 Deduced_Data_Type = "Int64"
 
 [entref]

--- a/config/output_schemas/tau_schema.toml
+++ b/config/output_schemas/tau_schema.toml
@@ -3,7 +3,7 @@ old_name = "reference"
 Deduced_Data_Type = "Int64"
 
 [period]
-old_name = "period"
+old_name = "period_year"
 Deduced_Data_Type = "Int64"
 
 [entref]

--- a/src/outputs/form_output_prep.py
+++ b/src/outputs/form_output_prep.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from src.imputation.pg_conversion import run_pg_conversion
 from src.staging.validation import flag_no_rand_spenders
+from src.outputs.outputs_helpers import create_period_year
 
 
 def form_output_prep(
@@ -33,13 +34,17 @@ def form_output_prep(
     no_rnd_spenders_filter = ~(
         (estimated_df["604"] == "No") & (estimated_df["211"] > 0)
     )
+
     outputs_df = estimated_df.copy().loc[no_rnd_spenders_filter]
+    outputs_df = create_period_year(outputs_df)
+
     tau_outputs_df = weighted_df.copy().loc[no_rnd_spenders_filter]
+    tau_outputs_df = create_period_year(tau_outputs_df)
 
     if ni_full_responses is not None:
         # Add required columns to NI data
         ni_full_responses = ni_full_responses.rename(
-            columns={"period_year": "period", "foc": "ultfoc"}
+            columns={"foc": "ultfoc"}
         )
         ni_full_responses["a_weight"] = 1
         ni_full_responses["604"] = "Yes"

--- a/src/outputs/long_form.py
+++ b/src/outputs/long_form.py
@@ -6,7 +6,7 @@ from typing import Callable, Dict, Any
 
 import src.outputs.map_output_cols as map_o
 from src.staging.validation import load_schema
-from src.outputs.outputs_helpers import create_output_df, create_period_year
+from src.outputs.outputs_helpers import create_output_df
 
 OutputMainLogger = logging.getLogger(__name__)
 
@@ -39,9 +39,6 @@ def output_long_form(
 
     # Filter for long-forms/NI (status mapping has already been done)
     df = df.loc[((df["formtype"] == "0001") | (df["formtype"] == "0003"))]
-
-    # Create a 'year' column
-    df = create_period_year(df)
 
     # Join foriegn ownership column using ultfoc mapper
     df = map_o.join_fgn_ownership(df, ultfoc_mapper)

--- a/src/outputs/short_form.py
+++ b/src/outputs/short_form.py
@@ -7,7 +7,7 @@ from typing import Callable, Dict, Any
 import src.outputs.map_output_cols as map_o
 from src.staging.validation import load_schema
 from src.imputation.imputation_helpers import fill_sf_zeros
-from src.outputs.outputs_helpers import create_output_df, create_period_year
+from src.outputs.outputs_helpers import create_output_df
 
 
 OutputMainLogger = logging.getLogger(__name__)
@@ -110,9 +110,6 @@ def output_short_form(
     NETWORK_OR_HDFS = config["global"]["network_or_hdfs"]
     paths = config[f"{NETWORK_OR_HDFS}_paths"]
     output_path = paths["output_path"]
-
-    # Create a 'year' column
-    df = create_period_year(df)
 
     # Join foriegn ownership column using ultfoc mapper
     df = map_o.join_fgn_ownership(df, ultfoc_mapper)

--- a/tests/test_outputs/test_outputs_helpers.py
+++ b/tests/test_outputs/test_outputs_helpers.py
@@ -1,8 +1,34 @@
 from src.outputs.outputs_helpers import create_output_df
+from src.outputs.outputs_helpers import create_period_year
 
 import pandas as pd
 import unittest
 from pandas._testing import assert_frame_equal
+
+
+class TestCreateNewCols(unittest.TestCase):
+    """Unittest for create news columns"""
+
+    def data_frame(self):
+        # create sample data
+        data = {"period": ["202201", "202206", "202109", "202112"]}
+
+        df = pd.DataFrame(data)
+        return df
+
+    def test_create_new_cols(self):
+        # Call the create_new_cols funtion
+        df_input = self.data_frame()
+        actual_result = create_period_year(df_input)
+
+        expected_result = pd.DataFrame(
+            {
+                "period": ["202201", "202206", "202109", "202112"],
+                "period_year": [2022, 2022, 2021, 2021],
+            }
+        )
+
+        assert_frame_equal(actual_result, expected_result)
 
 
 class TestSelectCols(unittest.TestCase):

--- a/tests/test_outputs/test_short_form.py
+++ b/tests/test_outputs/test_short_form.py
@@ -3,32 +3,7 @@ import pandas as pd
 import unittest
 from pandas._testing import assert_frame_equal
 
-from src.outputs.short_form import create_period_year, create_headcount_cols
-
-
-class TestCreateNewCols(unittest.TestCase):
-    """Unittest for create news columns"""
-
-    def data_frame(self):
-        # create sample data
-        data = {"period": ["202201", "202206", "202109", "202112"]}
-
-        df = pd.DataFrame(data)
-        return df
-
-    def test_create_new_cols(self):
-        # Call the create_new_cols funtion
-        df_input = self.data_frame()
-        actual_result = create_period_year(df_input)
-
-        expected_result = pd.DataFrame(
-            {
-                "period": ["202201", "202206", "202109", "202112"],
-                "period_year": [2022, 2022, 2021, 2021],
-            }
-        )
-
-        assert_frame_equal(actual_result, expected_result)
+from src.outputs.short_form import create_headcount_cols
 
 
 class TestCreateHeadcountCols:


### PR DESCRIPTION
Moved the `create_period_year()` function to `form_output_prep()`, so it can be pulled straight into all relevant outputs.  Adjusted schema's so all relevant outputs pull the period year rather than period.  
Moved the unit test into 'test_output_helpers()` so the it mirrors the code.
