### PR TITLE
RDRP-754: fixes to cols in frozen group output

### DIFF
--- a/config/output_schemas/frozen_group_schema.toml
+++ b/config/output_schemas/frozen_group_schema.toml
@@ -319,19 +319,19 @@ old_name = "250"
 Deduced_Data_Type = "int64"
 
 [q251]
-old_name = "q251"
+old_name = "251"
 Deduced_Data_Type = "int64"
 
 [q307]
-old_name = "q307"
+old_name = "307"
 Deduced_Data_Type = "int64"
 
 [q308]
-old_name = "q308"
+old_name = "308"
 Deduced_Data_Type = "int64"
 
 [q309]
-old_name = "q309"
+old_name = "309"
 Deduced_Data_Type = "int64"
 
 [q252]

--- a/src/outputs/frozen_group.py
+++ b/src/outputs/frozen_group.py
@@ -48,11 +48,14 @@ def output_frozen_group(
     paths = config[f"{NETWORK_OR_HDFS}_paths"]
     output_path = paths["output_path"]
 
+    df_gb = map_o.map_FG_cols_to_numeric(df_gb)
+    df_ni = map_o.map_FG_cols_to_numeric(df_ni)
+
     # Categorical columns that we have in BERD and NI data
     category_columns = [
         "period_year", "reference", "200", "201", "formtype",
         "employment", "ultfoc", "form_status",
-        "wowenterprisereference", "rusic",
+        "wowenterprisereference", "rusic", "251", "307", "308","309",
     ]
 
     # Numerical value columns that we have in BERD and NI data
@@ -70,7 +73,7 @@ def output_frozen_group(
     # Columns that we don't have that should have pd.NA values
     blank_columns = [
         "freeze_id", "period", "cell_id", "period_contributor_id",
-        "data_source", "q251", "q252", "q307", "q308", "q309",
+        "data_source",
     ]
 
     # Columns that we don't have that should have zero values
@@ -79,7 +82,7 @@ def output_frozen_group(
     zero_columns = [
         "q208", "q213", "q215", "q217", "q224", "q230", "q231", "q232",
         "q233", "q234", "q235", "q236", "q238", "q239", "q240", "q241",
-        "q253", "q254", "q255", "q256", "q257", "q258",
+        "q252", "q253", "q254", "q255", "q256", "q257", "q258",
     ]
 
     # Join foriegn ownership column using ultfoc mapper for GB

--- a/src/outputs/map_output_cols.py
+++ b/src/outputs/map_output_cols.py
@@ -62,18 +62,18 @@ def join_fgn_ownership(
             mapper_df, how="left", left_on="reference", right_on="ruref"
         )
         combined_df.drop(columns=["ruref"], inplace=True)
-        
-        # If the filtered_df already had "ultfoc", which is the case for TAU, 
-        # then after merging we will have two columns, ultfoc_x - blank, not 
+
+        # If the filtered_df already had "ultfoc", which is the case for TAU,
+        # then after merging we will have two columns, ultfoc_x - blank, not
         # needed, and ultfoc_y - with the codes we need. The following  section
-        # renames ultfoc_y to ultfoc, removes ultfoc_x and restores the 
+        # renames ultfoc_y to ultfoc, removes ultfoc_x and restores the
         # original column order.
         old_cols = list(main_df.columns)
         new_cols = list(combined_df.columns)
         if "ultfoc_y" in new_cols:
             combined_df = combined_df.rename(columns={"ultfoc_y": "ultfoc"})
             combined_df = combined_df[old_cols]
-         
+
 
         main_df = pd.concat([combined_df, ni_df]).reset_index(drop=True)
 
@@ -230,4 +230,35 @@ def map_to_numeric(df: pd.DataFrame):
 
     # Return columns as integers
     df = df.astype({"713": "Int64", "714": "Int64"})
+    return df
+
+
+def map_FG_cols_to_numeric(
+    df: pd.DataFrame,
+    col_list: list = ["251", "307", "308","309"]):
+    """Map specified cols in dataframe from letters to numeric format
+    Yes is mapped to 1
+    No is mapped to 2
+    Unanswered is mapped to 3
+
+    Args:
+        df (pd.DataFrame): The original dataframe
+
+    Returns:
+        df: Dataframe with numeric values for specified cols
+    """
+
+    for col in col_list:
+        df[col] = df[col].astype("object")
+        # Map the actual responses to the corresponding integer
+        mapper_dict = {"Yes": 1, "No": 2, "": 3}
+
+        df[col] = df[col].map(mapper_dict)
+
+        # Convert all nulls to unanswered (map to 3)
+        df.loc[df[col].isnull(), col] = 3
+
+        # Return columns as integers
+        df[col] = df[col].astype("Int64")
+
     return df


### PR DESCRIPTION
Makes required changes to cols in frozen group output.

In `map_FG_cols_to_numeric()` cols 251, 307, 308, 309 are encoded to:
Yes – 1
No –  2
Blank – 3

PLEASE NOTE: this is really similar to another function in helpers, but couldn't combine at this time due to potential impact on TAU and short form.  Should review  `map_FG_cols_to_numeric()` and `map_to_numeric()` and combine

Cols 251, 307, 308, 309 are then treated as cat cols.

Col q252 moved to be filled with zeros, in the same way as "q253", "q254", "q255", "q256", "q257", "q258

#### Code

- [ ] **Code runs** The code runs on my machine and/or CDSW
- [ ] **Conflicts resolved** There are no conflicts (I have performed a rebase if necessary)
- [ ] **Requirements** My/our code functions according to the requirements of the ticket
- [ ] **Dependencies** I have updated the environment yaml so it includes any new libraries I have used
- [ ] **Configuration file updated** any high level parameters that the user may interact with have been put into the config file (and imported to the script)
- [ ] **Clean Code**
    - [ ] Code is as [PEP 8]([url](https://peps.python.org/pep-0008/)) compliant as I can humanly make it
    - [ ] Code passess flake8 linting check
    - [ ] Code adheres to [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)
- [ ] **Type hints** All new functions have [type hints ](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html)


#### Documentation

Any new code includes all the following forms of documentation:

- [ ] **Function Documentation** Docstrings within the function(s')/methods have been created
    - [ ] Includes `Args` and `returns` for all major functions
    - [ ] The docstring details data types
- [ ] **Updated Documentation**: User and/or developer working doc has been updated

#### Data
- [ ] All data needed to run this script is available in Dev/Test
- [ ] All data is excluded from this pull request
- [ ] Secrets checker pre-commit passes

#### Testing
- [ ] **Unit tests** Unit tests have been created and are passing _or a new ticket to create tests has been created_

---

# Peer Review Section

- [ ] All requirements install from (updated) `environment.yaml`
- [ ] Documentation has been created and is clear - **check the working document**
- [ ] Doctrings ([Google format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)) have been created and accurately describe the function's functionality
- [ ] Unit tests pass, or if not present _a new ticket to create tests has been created_
- [ ] **Code runs** The code runs on reviewer's machine and/or CDSW

#### Final approval (post-review)

The author has responded to my review and made changes to my satisfaction.
- [ ] **I recommend merging this request.**

---

### Review comments

*Insert detailed comments here!*

These might include, but not exclusively:

- bugs that need fixing (does it work as expected? and does it work with other code
  that it is likely to interact with?)
- alternative methods (could it be written more efficiently or with more clarity?)
- documentation improvements (does the documentation reflect how the code actually works?)
- additional tests that should be implemented (do the tests effectively assure that it
  works correctly?)
- code style improvements (could the code be written more clearly?)
- Do the changes represent a change in functionality so the version number should increase? Start a discussion if so.
- As a review you can generates the same outputs from running the code

Your suggestions should be tailored to the code that you are reviewing.
Be critical and clear, but not mean. Ask questions and set actions.
