### PR TITLE
RDRP-1021 Fix bug in updating 604 after imputation

### DIFF
--- a/src/imputation/imputation_main.py
+++ b/src/imputation/imputation_main.py
@@ -106,10 +106,10 @@ def run_imputation(
     imputed_df = hlp.calculate_totals(imputed_df)
 
     # After TMI imputation, overwrite the "604" == "No" in any records with
-    # Status "check needed" (they are now being imputed)
+    # Status "check needed" (they are now being imputed")
     chk_mask = imputed_df["status"].str.contains("Check needed")
     imputation_mask = imputed_df["imp_marker"] == "TMI"
-    # Changing all records that meet the criteria to "604" == "Yes"
+
     imputed_df.loc[(chk_mask & imputation_mask), "604"] = "Yes"
 
     # join constructed rows back to the imputed df

--- a/src/imputation/imputation_main.py
+++ b/src/imputation/imputation_main.py
@@ -105,10 +105,10 @@ def run_imputation(
     # Perform TMI step 5, which calculates employment and headcount totals
     imputed_df = hlp.calculate_totals(imputed_df)
 
-    # After imputation, correction to overwrite the "604" == "No" in any records with
-    # Status "check needed"
+    # After TMI imputation, overwrite the "604" == "No" in any records with
+    # Status "check needed" (they are now being imputed)
     chk_mask = imputed_df["status"].str.contains("Check needed")
-    imputation_mask = imputed_df["imp_marker"].isin(["TMI", "CF", "MoR"])
+    imputation_mask = imputed_df["imp_marker"] == "TMI"
     # Changing all records that meet the criteria to "604" == "Yes"
     imputed_df.loc[(chk_mask & imputation_mask), "604"] = "Yes"
 


### PR DESCRIPTION
## Pull Request submission

**Bug found by BaU:**
A business is non-responding in 2023. This business in the backdata (2022) stated they did not perform R&D. MoR is applied to it, and the result shows a row with all zero values.

The correct behaviour should be: if they said No to R&D last year and not responding this year, they should be treated as No R&D this  year and not appear in SAS extract. 

**Cause of the bug:**
The status of q604 from 2022 to 2023 is copied during CF/ MoR, but there was a bug where this gets set back to "Yes" again on imputation_main.py ln 111, this should just be TMI.

This is fixed in this PR

#### Closes or fixes

* Detail the ticket(s) you are closing with this PR
Closes #1021


#### Code

- [ ] **Code runs** The code runs on my machine and/or CDSW
- [ ] **Conflicts resolved** There are no conflicts (I have performed a rebase if necessary)
- [ ] **Requirements** My/our code functions according to the requirements of the ticket
- [ ] **Dependencies** I have updated the environment yaml so it includes any new libraries I have used
- [ ] **Configuration file updated** any high level parameters that the user may interact with have been put into the config file (and imported to the script)
- [ ] **Clean Code**
    - [ ] Code is as [PEP 8]([url](https://peps.python.org/pep-0008/)) compliant as I can humanly make it
    - [ ] Code passess flake8 linting check
    - [ ] Code adheres to [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)
- [ ] **Type hints** All new functions have [type hints ](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html)


#### Documentation

Any new code includes all the following forms of documentation:

- [ ] **Function Documentation** Docstrings within the function(s')/methods have been created
    - [ ] Includes `Args` and `returns` for all major functions
    - [ ] The docstring details data types
- [ ] **Updated Documentation**: User and/or developer working doc has been updated

#### Data
- [ ] All data needed to run this script is available in Dev/Test
- [ ] All data is excluded from this pull request
- [ ] Secrets checker pre-commit passes

#### Testing
- [ ] **Unit tests** Unit tests have been created and are passing _or a new ticket to create tests has been created_

---

# Peer Review Section

- [ ] All requirements install from (updated) `requirements.txt`
- [ ] Documentation has been created and is clear - **check the working document**
- [ ] Doctrings ([Google format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)) have been created and accurately describe the function's functionality
- [ ] Unit tests pass, or if not present _a new ticket to create tests has been created_
- [ ] **Code runs** The code runs on reviewer's machine and/or CDSW

#### Final approval (post-review)

The author has responded to my review and made changes to my satisfaction.
- [ ] **I recommend merging this request.**

---

### Review comments

*Insert detailed comments here!*

These might include, but not exclusively:

- bugs that need fixing (does it work as expected? and does it work with other code
  that it is likely to interact with?)
- alternative methods (could it be written more efficiently or with more clarity?)
- documentation improvements (does the documentation reflect how the code actually works?)
- additional tests that should be implemented (do the tests effectively assure that it
  works correctly?)
- code style improvements (could the code be written more clearly?)
- Do the changes represent a change in functionality so the version number should increase? Start a discussion if so.
- As a review you can generates the same outputs from running the code

Your suggestions should be tailored to the code that you are reviewing.
Be critical and clear, but not mean. Ask questions and set actions.
