### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pytest-action.yaml
+++ b/.github/workflows/pytest-action.yaml
@@ -1,5 +1,7 @@
 name: Run pytest on pull request to develop
 
+permissions:
+  contents: read
 # runs on every pull request to develop
 on:
   pull_request:

--- a/.github/workflows/pytest-action.yaml
+++ b/.github/workflows/pytest-action.yaml
@@ -2,6 +2,7 @@ name: Run pytest on pull request to develop
 
 permissions:
   contents: read
+  pull_requests: write
 # runs on every pull request to develop
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ONSdigital/research-and-development/security/code-scanning/4](https://github.com/ONSdigital/research-and-development/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow to explicitly limit the permissions granted to the GITHUB_TOKEN. The block should be added at the root level (before `jobs:`) to apply to all jobs in the workflow, unless a job requires different permissions. Based on the workflow, the minimal required permissions are likely `contents: read` (for checking out code) and possibly `pull-requests: write` (if the coverage comment action needs to post comments to pull requests). However, if you want to start with the absolute minimum, use `contents: read`. If you find that the coverage comment action fails due to insufficient permissions, you can add `pull-requests: write` as needed.

The change should be made at the top of `.github/workflows/pytest-action.yaml`, after the `name:` line and before `jobs:`. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
